### PR TITLE
Switch to announce peer cloning strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 callgrind.*
 oprofile_data
+perf.data*

--- a/src/response/success.rs
+++ b/src/response/success.rs
@@ -5,14 +5,14 @@ use tracker::stats::StatsResponse;
 use bip_bencode::Bencode;
 use std::collections::BTreeMap;
 
-pub enum SuccessResponse<'a> {
-    Announce(AnnounceResponse<'a>),
+pub enum SuccessResponse {
+    Announce(AnnounceResponse),
     Scrape(ScrapeResponse),
     Stats(StatsResponse),
 }
 
-impl<'a> SuccessResponse<'a> {
-    pub fn http_resp(&'a self) -> Vec<u8> {
+impl SuccessResponse {
+    pub fn http_resp(& self) -> Vec<u8> {
         match *self {
             SuccessResponse::Announce(ref a) => bencode_announce(a),
             SuccessResponse::Scrape(ref s) => bencode_scrape(s),

--- a/src/tracker/announce.rs
+++ b/src/tracker/announce.rs
@@ -25,32 +25,86 @@ pub enum Action {
     Stopped,
 }
 
-pub struct AnnounceResponse<'a> {
-    announce: Announce,
-    guard: MutexGuard<'a, HashMap<String, Torrent>>,
+pub struct AnnouncePeer {
+    pub id: String,
+    pub ipv4: Option<SocketAddrV4>,
+    pub ipv6: Option<SocketAddrV6>,
 }
 
-impl<'a> AnnounceResponse<'a> {
-    pub fn new(announce: Announce,
-               guard: MutexGuard<HashMap<String, Torrent>>)
-               -> AnnounceResponse {
-        AnnounceResponse {
-            announce: announce,
-            guard: guard
+pub struct AnnounceResponse {
+    peers: Peers,
+    stats: Stats,
+    compact: bool
+}
+
+impl AnnouncePeer {
+    pub fn get_ipv4_bytes(&self) -> Option<Vec<u8>> {
+        match self.ipv4 {
+            None => None,
+            Some(sock) => {
+                let mut v = Vec::with_capacity(6);
+                v.extend(sock.ip().octets().to_vec());
+                v.extend(u16_to_u8(sock.port()));
+                Some(v)
+            }
         }
     }
 
-    pub fn peers(&self) -> Peers {
-        let t = self.guard.get(&self.announce.info_hash).unwrap();
-        t.get_peers(self.announce.numwant.clone(), self.announce.action.clone())
+    pub fn get_ipv4_str(&self) -> Option<String> {
+        match self.ipv4 {
+            None => None,
+            Some(sock) => {
+                Some(format!("{}", sock.ip()))
+            }
+        }
     }
 
-    pub fn stats(&self) -> Stats {
-        let t = self.guard.get(&self.announce.info_hash).unwrap();
-        t.get_stats()
+    pub fn get_ipv6_bytes(&self) -> Option<Vec<u8>> {
+        match self.ipv6 {
+            None => None,
+            Some(sock) => {
+                let mut v = Vec::with_capacity(18);
+                for seg in sock.ip().segments().iter() {
+                    v.extend(u16_to_u8(seg.clone()));
+                }
+                v.extend(u16_to_u8(sock.port()));
+                Some(v)
+            }
+        }
+    }
+
+    pub fn get_ipv6_str(&self) -> Option<String> {
+        match self.ipv6 {
+            None => None,
+            Some(sock) => {
+                Some(format!("{}", sock.ip()))
+            }
+        }
+    }
+}
+
+fn u16_to_u8(i: u16) -> Vec<u8> {
+    vec![(i >> 8) as u8, (i & 0xff) as u8]
+}
+
+impl AnnounceResponse {
+    pub fn new(peers: Peers, stats: Stats, compact: bool) -> AnnounceResponse {
+        AnnounceResponse {
+            peers: peers,
+            stats: stats,
+            compact: compact,
+        }
+    }
+
+    pub fn peers(&self) -> &Peers {
+        &self.peers
+    }
+
+    pub fn stats(&self) -> &Stats {
+        &self.stats
     }
 
     pub fn compact(&self) -> bool {
-        self.announce.compact
+        self.compact
     }
 }

--- a/src/tracker/announce.rs
+++ b/src/tracker/announce.rs
@@ -1,8 +1,6 @@
 use std::net::{SocketAddrV4, SocketAddrV6};
-use std::sync::MutexGuard;
-use std::collections::HashMap;
 
-use tracker::torrent::{Stats, Peers, Torrent};
+use tracker::torrent::{Stats, Peers};
 
 pub struct Announce {
     pub info_hash: String,

--- a/src/tracker/peer.rs
+++ b/src/tracker/peer.rs
@@ -1,4 +1,4 @@
-use tracker::announce::Announce;
+use tracker::announce::{Announce, AnnouncePeer};
 
 use time::SteadyTime;
 use std::net::{SocketAddrV4, SocketAddrV6};
@@ -61,53 +61,13 @@ impl Peer {
         d
     }
 
-    pub fn get_ipv4_bytes(&self) -> Option<Vec<u8>> {
-        match self.ipv4 {
-            None => None,
-            Some(sock) => {
-                let mut v = Vec::with_capacity(6);
-                v.extend(sock.ip().octets().to_vec());
-                v.extend(u16_to_u8(sock.port()));
-                Some(v)
-            }
+    pub fn get_announce_peer(&self) -> AnnouncePeer {
+        AnnouncePeer {
+            id: self.id.clone(),
+            ipv4: self.ipv4.clone(),
+            ipv6: self.ipv6.clone(),
         }
     }
-
-    pub fn get_ipv4_str(&self) -> Option<String> {
-        match self.ipv4 {
-            None => None,
-            Some(sock) => {
-                Some(format!("{}", sock.ip()))
-            }
-        }
-    }
-
-    pub fn get_ipv6_bytes(&self) -> Option<Vec<u8>> {
-        match self.ipv6 {
-            None => None,
-            Some(sock) => {
-                let mut v = Vec::with_capacity(18);
-                for seg in sock.ip().segments().iter() {
-                    v.extend(u16_to_u8(seg.clone()));
-                }
-                v.extend(u16_to_u8(sock.port()));
-                Some(v)
-            }
-        }
-    }
-
-    pub fn get_ipv6_str(&self) -> Option<String> {
-        match self.ipv6 {
-            None => None,
-            Some(sock) => {
-                Some(format!("{}", sock.ip()))
-            }
-        }
-    }
-}
-
-fn u16_to_u8(i: u16) -> Vec<u8> {
-    vec![(i >> 8) as u8, (i & 0xff) as u8]
 }
 
 impl Delta {


### PR DESCRIPTION
This reduces the time a mutex has to be held, yielding throughput increases of around 1.5x
